### PR TITLE
Test actions reducers

### DIFF
--- a/src/actions/index.test.js
+++ b/src/actions/index.test.js
@@ -1,0 +1,47 @@
+import * as actions from '../actions'
+
+describe('actions', () => {
+  it('should have a type of HAS_ERROR', () => {
+    const message = 'Something went wrong'
+    const expectedAction = {
+      type: 'HAS_ERROR',
+      message
+    }
+
+    const result = actions.hasError(message)
+    expect(result).toEqual(expectedAction)
+  })
+
+  it('should have a type of IS_LOADING', () => {
+    const isLoading = false
+    const expectedAction = {
+      type: 'IS_LOADING',
+      isLoading
+    }
+
+    const result = actions.isLoading(isLoading)
+    expect(result).toEqual(expectedAction)
+  })
+
+  it('should have a type of SET_SURVEY', () => {
+    const survey = { survey: 'survey object'}
+    const expectedAction = {
+      type: 'SET_SURVEY',
+      survey
+    }
+
+    const result = actions.setSurvey(survey)
+    expect(result).toEqual(expectedAction)
+  })
+
+  it('should have a type of SET_COHORTS', () => {
+    const cohorts = ['1810', '1811']
+    const expectedAction = {
+      type: 'SET_COHORTS',
+      cohorts
+    }
+
+    const result = actions.setCohorts(cohorts)
+    expect(result).toEqual(expectedAction)
+  })
+})

--- a/src/reducers/hasErrorReducer.test.js
+++ b/src/reducers/hasErrorReducer.test.js
@@ -1,0 +1,17 @@
+import { hasErrorReducer } from './hasErrorReducer'
+import * as actions from '../actions'
+
+describe('hasErrorReducer', () => {
+  it('should return an empty string by default', () => {
+    const expected = ''
+    const result = hasErrorReducer(undefined, {})
+    expect(result).toEqual(expected)
+  })
+
+  it('should return a string if the action type is HAS_ERROR', () => {
+    const message = 'Something went wrong'
+    const action = actions.hasError(message)
+    const result = hasErrorReducer(undefined, action)
+    expect(result).toEqual(message)
+  })
+})

--- a/src/reducers/index.test.js
+++ b/src/reducers/index.test.js
@@ -1,0 +1,10 @@
+import rootReducer from './index'
+import { createStore } from 'redux'
+import { setCohortsReducer } from './setCohortsReducer'
+
+describe('rootReducer', () => {
+  it('should return a store', () => {
+    const store = createStore(rootReducer)
+    expect(store.getState().cohorts).toEqual(setCohortsReducer(undefined, {}))
+  })
+})

--- a/src/reducers/isLoadingReducer.test.js
+++ b/src/reducers/isLoadingReducer.test.js
@@ -1,0 +1,17 @@
+import { isLoadingReducer } from './isLoadingReducer'
+import * as actions from '../actions'
+
+describe('isLoadingReducer', () => {
+  it('should return state by default', () => {
+    const expected = false
+    const result = isLoadingReducer(undefined, {})
+    expect(result).toEqual(expected)
+  })
+
+  it('should return a boolean if the action type is IS_LOADING', () => {
+    const bool = true
+    const action = actions.isLoading(bool)
+    const result = isLoadingReducer(undefined, action)
+    expect(result).toEqual(bool)
+  })
+})

--- a/src/reducers/setCohortsReducer.test.js
+++ b/src/reducers/setCohortsReducer.test.js
@@ -1,0 +1,18 @@
+import { setCohortsReducer } from './setCohortsReducer'
+import * as actions from '../actions'
+
+describe('setCohortsReducer', () => {
+  it('should return state by default', () => {
+    const expected = []
+    const result = setCohortsReducer(undefined, {})
+    expect(result).toEqual(expected)
+  })
+
+  it('should set state with an array of cohorts if the type is SET_COHORTS', () => {
+    const initialState = []
+    const cohorts = ['1811', '1901']
+    const action = actions.setCohorts(cohorts)
+    const result = setCohortsReducer(undefined, action)
+    expect(result).toEqual(cohorts)
+  })
+})

--- a/src/reducers/setSurveyReducer.test.js
+++ b/src/reducers/setSurveyReducer.test.js
@@ -1,0 +1,17 @@
+import { setSurveyReducer } from './setSurveyReducer'
+import * as actions from '../actions'
+
+describe('setSurveyReducer', () => {
+  it('should return state by default', () => {
+    const expected = {}
+    const result = setSurveyReducer(undefined, {})
+    expect(result).toEqual(expected)
+  })
+
+  it('should set state with a survey object if the type is SET_SURVEY', () => {
+    const survey = { survey: 'new survey'}
+    const action = actions.setSurvey(survey)
+    const result = setSurveyReducer(undefined, action)
+    expect(result).toEqual(survey) 
+  })
+})


### PR DESCRIPTION
### What does this change do?
- Tests the following actions: hasError, isLoading, setSurvey, setCohorts
- Tests the following reducers: hasErrorReducer, isLoadingReducer, setSurveyReducer, setCohortsReducer, rootReducer

### Link to related issues:
[Test current components, actions, reducers, thunks](https://trello.com/c/78BG2TUg/42-test-current-components-actions-reducers-thunks)

### How was this change implemented?
- Created new test files and made sure all were passing 

### Link to next issue:
- Continue [Test current components, actions, reducers, thunks](https://trello.com/c/78BG2TUg/42-test-current-components-actions-reducers-thunks)

### How does this PR make you feel?
![image](https://media.giphy.com/media/xUOwGpCfvJvEHtNfdS/giphy.gif)
