### PR TITLE
Recipient form test

### DIFF
--- a/src/containers/RecipientForm/RecipientForm.test.js
+++ b/src/containers/RecipientForm/RecipientForm.test.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { RecipientForm, mapStateToProps } from './RecipientForm'
+
+describe('RecipientForm', () => {
+  let mockState
+  let wrapper
+
+  beforeEach(() => {
+    mockState = {
+      cohorts: [
+        { id: 1 ,
+        name: "1811" },
+        { id: 2,
+        name: "1901" }
+        ]
+    }
+    wrapper = shallow(
+      <RecipientForm 
+        cohorts={mockState.cohorts}
+      />
+    )
+  })
+
+  it('should match the snapshot', () => {
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should have proper default state', () => {
+    expect(wrapper.state()).toEqual({
+      cohort_id: 0
+    })
+  })
+
+  it('should', () => {
+    
+  })
+})

--- a/src/containers/RecipientForm/RecipientForm.test.js
+++ b/src/containers/RecipientForm/RecipientForm.test.js
@@ -5,6 +5,7 @@ import { RecipientForm, mapStateToProps } from './RecipientForm'
 describe('RecipientForm', () => {
   let mockState
   let wrapper
+  let mockEvent
 
   beforeEach(() => {
     mockState = {
@@ -32,7 +33,13 @@ describe('RecipientForm', () => {
     })
   })
 
-  it('should', () => {
-    
+  it('should set state with the cohort id', () => {
+    mockEvent = { target: { value: "19"} }
+
+    wrapper.instance().handleChange(mockEvent)
+
+    expect(wrapper.instance().state).toEqual({
+      cohort_id: 19
+    })
   })
 })

--- a/src/containers/RecipientForm/RecipientForm.test.js
+++ b/src/containers/RecipientForm/RecipientForm.test.js
@@ -42,4 +42,31 @@ describe('RecipientForm', () => {
       cohort_id: 19
     })
   })
+  
+  describe('mapStateToProps', () => {
+    it('should return the expected props as state', () => {
+      mockState = {
+        cohorts: [
+          { id: 1 ,
+          name: "1811" },
+          { id: 2,
+          name: "1901" }
+          ],
+        fakeState: "fakeState"
+      }
+      const expected = {
+        cohorts: [
+          { id: 1 ,
+          name: "1811" },
+          { id: 2,
+          name: "1901" }
+          ]
+      }
+
+      const mappedProps = mapStateToProps(mockState)
+
+      expect(mappedProps).toEqual(expected)
+    })
+  })
+  
 })

--- a/src/containers/RecipientForm/__snapshots__/RecipientForm.test.js.snap
+++ b/src/containers/RecipientForm/__snapshots__/RecipientForm.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RecipientForm should match the snapshot 1`] = `
+<div>
+  <h2>
+    Select Recipients
+  </h2>
+  <h3>
+    Program
+  </h3>
+  <select>
+    <option>
+      BE
+    </option>
+    <option>
+      FE
+    </option>
+  </select>
+  <h3>
+    Cohort
+  </h3>
+  <select
+    onChange={[Function]}
+  >
+    <option
+      value="0"
+    >
+      select a cohort
+    </option>
+    <option
+      key="1"
+      value={1}
+    >
+      1811
+    </option>
+    <option
+      key="2"
+      value={2}
+    >
+      1901
+    </option>
+  </select>
+  <button
+    disabled={true}
+  >
+    Send
+  </button>
+</div>
+`;


### PR DESCRIPTION
### What does this change do?
- fully tests RecipientForm.js
<img width="664" alt="Screen Shot 2019-05-22 at 2 25 02 PM" src="https://user-images.githubusercontent.com/43019784/58206465-f2feb800-7c9d-11e9-9bf5-b21a9044c63f.png">

### Link to related issues:
[TEST current components, actions, reducers, thunks](https://trello.com/c/78BG2TUg/42-test-current-components-actions-reducers-thunks)

### How was this change implemented?
- tested each piece of functionality on the container

### Link to next issue:
[TEST current components, actions, reducers, thunks](https://trello.com/c/78BG2TUg/42-test-current-components-actions-reducers-thunks)

### How does this PR make you feel?
![image](https://media.giphy.com/media/5z9KbV49k2odVymZVf/giphy-downsized.gif)
