### PR TITLE
Refactor for be

### DIFF
--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -7,17 +7,16 @@ export class Question extends Component {
     this.state = {
       id: this.props.id,
       questionTitle: '',
-      option_1: {pointValue: 1, questionText: ''},
-      option_2: {pointValue: 2, questionText: ''},
-      option_3: {pointValue: 3, questionText: ''},
-      option_4: {pointValue: 4, questionText: ''},
-      option_5: {pointValue: 5, questionText: ''}
+      option_1: {pointValue: 1, description: ''},
+      option_2: {pointValue: 2, description: ''},
+      option_3: {pointValue: 3, description: ''},
+      option_4: {pointValue: 4, description: ''}
     }
   }
 
   handleChange = (e) => {
     const { name, value } = e.target
-      this.setState({  [name] : {pointValue: this.state[name].pointValue, questionText: value} })
+      this.setState({  [name] : {pointValue: this.state[name].pointValue, description: value} })
   }
 
   handleTitleChange = (e) => {
@@ -28,7 +27,18 @@ export class Question extends Component {
 
   handleSubmit = (e) => {
     e.preventDefault()
-    this.props.updateQuestions(this.state)
+    let optionsArr = []
+    Object.keys(this.state).forEach(el => {
+      if(el.includes('option')) {
+        optionsArr.push({ [el] : {pointValue: this.state[el].pointValue, description: this.state[el].description}})
+      }
+    })
+    let newQuestion = {
+      id: this.state.id,
+      questionTitle: this.state.questionTitle,
+      options: optionsArr
+    }
+    this.props.updateQuestions(newQuestion)
   }
 
   render() {
@@ -55,7 +65,7 @@ export class Question extends Component {
               name="option_1"
               id='op1'
               className='option'
-              value={this.state.option_1.questionText}
+              value={this.state.option_1.description}
               onChange={this.handleChange} />
           </div>
           <div className='option'>
@@ -67,7 +77,7 @@ export class Question extends Component {
               placeholder="Option description"
               name="option_2"
               className='option'
-              value={this.state.option_2.questionText}
+              value={this.state.option_2.description}
               onChange={this.handleChange} />
           </div>
           <div className='option'>
@@ -79,7 +89,7 @@ export class Question extends Component {
               placeholder="Option description"
               name="option_3"
               className='option'
-              value={this.state.option_3.questionText}
+              value={this.state.option_3.description}
               onChange={this.handleChange} />
           </div>
           <div className='option'>
@@ -91,20 +101,8 @@ export class Question extends Component {
               placeholder="Option description"
               name="option_4"
               className='option'
-              value={this.state.option_4.questionText}
+              value={this.state.option_4.description}
               onChange={this.handleChange} />
-          </div>
-          <div className='option'>
-          <input
-            type="radio"
-            name="radio" />
-          <input
-            type="text"
-            placeholder="Option description"
-            name="option_5"
-            className='option'
-            value={this.state.option_5.questionText}
-            onChange={this.handleChange} />
           </div>
         </div>
       </form>

--- a/src/components/Question/Question.test.js
+++ b/src/components/Question/Question.test.js
@@ -44,17 +44,31 @@ describe('Question', () => {
 
   it('should call updateQuestions when handleSubmit is invoked', () => {
     const preventDefault = { preventDefault: jest.fn()}
-    const updatedState = {
-      id: 'abc',
-      questionTitle: 'New Q',
+    const mockState = {
+      id: 'abd',
+      questionTitle: 'New Question',
       option_1: {pointValue: 1, description: 'a'},
       option_2: {pointValue: 2, description: 'b'},
       option_3: {pointValue: 3, description: 'c'},
       option_4: {pointValue: 4, description: 'd'}
     }
+
+    const optionsArr = [
+      { option_1: {pointValue: 1, description: 'a'} },
+      { option_2: {pointValue: 2, description: 'b'} },
+      { option_3: {pointValue: 3, description: 'c'} },
+      { option_4: {pointValue: 4, description: 'd'} }
+    ]
+
+    wrapper.setState(mockState)
     
-    wrapper.setState(updatedState)
+    const newQuestion = {
+      id: 'abd',
+      questionTitle: 'New Question',
+      options: optionsArr,
+    }
+    
     wrapper.instance().handleSubmit(preventDefault)
-    expect(mockFn).toHaveBeenCalledWith(updatedState)
+    expect(mockFn).toHaveBeenCalledWith(newQuestion)
   })
 })

--- a/src/components/Question/Question.test.js
+++ b/src/components/Question/Question.test.js
@@ -21,20 +21,19 @@ describe('Question', () => {
     const defaultState = {
       id: 'abc',
       questionTitle: '',
-      option_1: {pointValue: 1, questionText: ''},
-      option_2: {pointValue: 2, questionText: ''},
-      option_3: {pointValue: 3, questionText: ''},
-      option_4: {pointValue: 4, questionText: ''},
-      option_5: {pointValue: 5, questionText: ''}
+      option_1: {pointValue: 1, description: ''},
+      option_2: {pointValue: 2, description: ''},
+      option_3: {pointValue: 3, description: ''},
+      option_4: {pointValue: 4, description: ''}
     }
 
     expect(wrapper.state()).toEqual(defaultState)
   })
 
-  it('should update questionText in state on change', () => {
+  it('should update description in state on change', () => {
     const mockEvent = { target: { name: 'option_1', value: 'First Option'}}
     wrapper.find('#op1').simulate('change', mockEvent)
-    expect(wrapper.state('option_1')).toEqual({ "pointValue": 1, "questionText": 'First Option'})
+    expect(wrapper.state('option_1')).toEqual({ "pointValue": 1, "description": 'First Option'})
   })
 
   it('should update questionTitle in state on change', () => {
@@ -48,11 +47,10 @@ describe('Question', () => {
     const updatedState = {
       id: 'abc',
       questionTitle: 'New Q',
-      option_1: {pointValue: 1, questionText: 'a'},
-      option_2: {pointValue: 2, questionText: 'b'},
-      option_3: {pointValue: 3, questionText: 'c'},
-      option_4: {pointValue: 4, questionText: 'd'},
-      option_5: {pointValue: 5, questionText: 'e'}
+      option_1: {pointValue: 1, description: 'a'},
+      option_2: {pointValue: 2, description: 'b'},
+      option_3: {pointValue: 3, description: 'c'},
+      option_4: {pointValue: 4, description: 'd'}
     }
     
     wrapper.setState(updatedState)

--- a/src/components/Question/__snapshots__/Question.test.js.snap
+++ b/src/components/Question/__snapshots__/Question.test.js.snap
@@ -83,22 +83,6 @@ exports[`Question should match the snapshot 1`] = `
         value=""
       />
     </div>
-    <div
-      className="option"
-    >
-      <input
-        name="radio"
-        type="radio"
-      />
-      <input
-        className="option"
-        name="option_5"
-        onChange={[Function]}
-        placeholder="Option description"
-        type="text"
-        value=""
-      />
-    </div>
   </div>
 </form>
 `;

--- a/src/containers/NewSurvey/NewSurvey.js
+++ b/src/containers/NewSurvey/NewSurvey.js
@@ -37,7 +37,6 @@ export class NewSurvey extends Component {
   }
 
   updateQuestions = (newQuestion) => {
-    console.log(newQuestion)
     if(this.state.questions.length) {
       const updatedQuestions = this.state.questions.map(question => {
         if (question.id === newQuestion.id) {

--- a/src/containers/NewSurvey/NewSurvey.js
+++ b/src/containers/NewSurvey/NewSurvey.js
@@ -37,6 +37,7 @@ export class NewSurvey extends Component {
   }
 
   updateQuestions = (newQuestion) => {
+    console.log(newQuestion)
     if(this.state.questions.length) {
       const updatedQuestions = this.state.questions.map(question => {
         if (question.id === newQuestion.id) {


### PR DESCRIPTION
### What does this change do?
- Refactor naming conventions and datatypes for BE consistency

### How was this change implemented?
- Remove 5th option to match BE
- Rename 'questionText' to 'description' to match BE
- Set the options for each question in an array to match BE

### How is this change tested?
- Update tests for changes described above

### Link to next issue:
[Write thunk for POST request for a new survey, trigger action on RecipientForm.js](https://trello.com/c/Ro8z4p4A/44-write-thunk-for-post-request-for-a-new-survey-trigger-action-on-recipientformjs)

### How does this PR make you feel?
@kimmichurri, I LOLed: 
![image](https://media.giphy.com/media/B13MdQvRr8j487BsPO/giphy-downsized.gif)
