### PR TITLE
Debug survey responses

### DIFF
--- a/src/containers/Response/Response.js
+++ b/src/containers/Response/Response.js
@@ -7,13 +7,14 @@ export class Response extends Component {
     super(props)
     this.state={
       responses: [],
-      displayQuestions: false
+      displayQuestions: false,
+      saveResponses: false,
     }
   }
 
   completeSurvey = () => {
     this.setState({
-      displayQuestions: !this.state.displayQuestions
+      displayQuestions: true
     })
   }
 
@@ -66,7 +67,8 @@ export class Response extends Component {
     } else {
       this.props.collectResponses(this.state.responses)
       this.setState({
-        displayQuestions: !this.state.displayQuestions
+        displayQuestions: false,
+        saveResponses: true
       })
     }
   }
@@ -79,7 +81,7 @@ export class Response extends Component {
     return (
       <div className='member-survey'>
         <button onClick={this.completeSurvey} className=
-        'response-button'>
+        'response-button' disabled={this.state.saveResponses}>
           Give {this.props.member.name} Feedback
         </button>
         {this.state.displayQuestions && this.renderQuestions()}

--- a/src/containers/Response/Response.js
+++ b/src/containers/Response/Response.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react'
 import ResponseCard from '../ResponseCard/ResponseCard'
+import cogoToast from 'cogo-toast'
+
 export class Response extends Component {
   constructor(props) {
     super(props)
@@ -59,10 +61,18 @@ export class Response extends Component {
   }
 
   closeResponse = () => {
-    this.props.collectResponses(this.state.responses)
-    this.setState({
-      displayQuestions: !this.state.displayQuestions
-    })
+    if (this.state.responses.length < this.props.questions.length) {
+      this.warnToast('Please answer each question before saving feedback')
+    } else {
+      this.props.collectResponses(this.state.responses)
+      this.setState({
+        displayQuestions: !this.state.displayQuestions
+      })
+    }
+  }
+
+  warnToast = (message) => {
+    cogoToast.warn(message, {position: 'bottom-left'})
   }
 
   render() {

--- a/src/containers/Response/Response.test.js
+++ b/src/containers/Response/Response.test.js
@@ -51,7 +51,8 @@ describe('Response', () => {
   it('should have a default state', () => {
     const expected = {
       responses: [],
-      displayQuestions: false
+      displayQuestions: false,
+      saveResponses: false,
     }
     expect(wrapper.state()).toEqual(expected)
   })

--- a/src/containers/Response/Response.test.js
+++ b/src/containers/Response/Response.test.js
@@ -169,9 +169,22 @@ describe('Response', () => {
     expect(wrapper.state('responses')).toEqual(expected)
   })
 
-  it('should toggle displayQuestions when closeResponse is called', () => {
-    expect(wrapper.state('displayQuestions')).toBe(false)
+  it('should call warnToast when closeResponse is called', () => {
+    const warnToastSpy = jest.spyOn(wrapper.instance(), 'warnToast')
+    wrapper.setState({
+      responses: [ { question: 4 } ]
+    })
     wrapper.instance().closeResponse()
-    expect(wrapper.state('displayQuestions')).toBe(true)
+    expect(warnToastSpy).toHaveBeenCalled()
+
+  })
+
+  it('should toggle displayQuestions when closeResponse is called', () => {
+    wrapper.setState({
+      responses: [ { question: 1 }, { question: 2 } ],
+      displayQuestions: true
+    })
+    wrapper.instance().closeResponse()
+    expect(wrapper.state('displayQuestions')).toBe(false)
   })
 })

--- a/src/containers/Response/__snapshots__/Response.test.js.snap
+++ b/src/containers/Response/__snapshots__/Response.test.js.snap
@@ -6,6 +6,7 @@ exports[`Response should match the snapshot 1`] = `
 >
   <button
     className="response-button"
+    disabled={false}
     onClick={[Function]}
   >
     Give 

--- a/src/containers/StudentSurvey/StudentSurvey.js
+++ b/src/containers/StudentSurvey/StudentSurvey.js
@@ -9,6 +9,7 @@ export class StudentSurvey extends Component {
     super(props);
     this.state = {
       allResponses: [],
+      membersReviewed: 0,
     }
   }
 
@@ -39,17 +40,19 @@ export class StudentSurvey extends Component {
   collectResponses = (individualResponse) => {
     if(this.state.allResponses.length >= 1) {
       this.setState({
-        allResponses: [...this.state.allResponses, ...individualResponse]
+        allResponses: [...this.state.allResponses, ...individualResponse],
+        membersReviewed: this.state.membersReviewed + 1
       })
     } else {
       this.setState({
-        allResponses: [...individualResponse]
+        allResponses: [...individualResponse],
+        membersReviewed: this.state.membersReviewed + 1
       })
     }
   }
 
   postResponse = async () => {
-    if(!this.state.allResponses.length) {
+    if(this.state.membersReviewed < this.state.members.length) {
       this.warnToast('Please complete surveys before submitting your response')
     } else {
       const url = "https://turing-feedback-api.herokuapp.com/api/v1/responses"

--- a/src/containers/StudentSurvey/StudentSurvey.scss
+++ b/src/containers/StudentSurvey/StudentSurvey.scss
@@ -61,6 +61,10 @@
   &:focus {
     outline: none;
   }
+  &:disabled {
+    background-color: $light-grey;
+    cursor: not-allowed;
+  }
 }
 
 .close-button-container {

--- a/src/containers/StudentSurvey/StudentSurvey.test.js
+++ b/src/containers/StudentSurvey/StudentSurvey.test.js
@@ -15,7 +15,8 @@ describe('StudentSurvey', () => {
     mockStudentSurveys = [
       { 
         id: 1, 
-        surveyName: "Survey 1", 
+        surveyName: "Survey 1",
+        questions: [ { id: 7 }, { id: 8 } ], 
         groups: [{members: [{id: 1, name: "name1"}, {id: 2, name: "name2"}]}]},
     ]
     mockHandlePost = jest.fn()
@@ -33,6 +34,65 @@ describe('StudentSurvey', () => {
 
   it('should match the snapshot', () => {
     expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should have default state', () => {
+    expect(wrapper.state('allResponses')).toEqual([])
+    expect(wrapper.state('membersReviewed')).toBe(0)
+  })
+
+  it('should set state on componentDidMount', () => {
+    const expected = {
+      allResponses: [],
+      membersReviewed: 0,
+      surveyName: 'Survey 1',
+      id: 1,
+      questions: [ { id: 7 }, { id: 8} ],
+      members: [{id: 1, name: "name1"}, {id: 2, name: "name2"}], 
+    }
+    wrapper.instance().componentDidMount()
+    expect(wrapper.state()).toEqual(expected)
+  })
+  
+  it('should return a Response component for each member', () => {
+    wrapper.instance().componentDidMount()
+    const result = wrapper.instance().renderResponse()
+    expect(result).toHaveLength(2)
+  })
+
+  it('should update empty allResponses in state if collectResponses is called', () => {
+    wrapper.setState({
+      allResponses: []
+    })
+    const individualResponse = [{ question: 4, answer: 2, member: 7 }]
+    wrapper.instance().collectResponses(individualResponse)
+    expect(wrapper.state('allResponses')).toEqual(individualResponse)
+    expect(wrapper.state('membersReviewed')).toEqual(1)
+  })
+
+  it('should update populated allResponses in state if collectResponses is called', () => {
+    wrapper.setState({
+      allResponses: [{ question: 5, answer: 3, member: 2 }]
+    })
+    const individualResponse = [{ question: 4, answer: 2, member: 7 }]
+    const expected = [{ question: 5, answer: 3, member: 2 }, { question: 4, answer: 2, member: 7 }]
+    wrapper.instance().collectResponses(individualResponse)
+    expect(wrapper.state('allResponses')).toEqual(expected)
+  })
+
+
+  it('should call warnToast if membersReviewed is less than the number of members', () => {
+    const warnToastSpy = jest.spyOn(wrapper.instance(), 'warnToast')
+    wrapper.instance().postResponse()
+    expect(warnToastSpy).toHaveBeenCalled()
+  })
+
+  it('should call handlePost when postResponse is called', () => {
+    const individualResponse = [{ question: 4, answer: 2, member: 7 }]
+    wrapper.instance().collectResponses(individualResponse)
+    wrapper.instance().collectResponses(individualResponse)
+    wrapper.instance().postResponse()
+    expect(mockHandlePost).toHaveBeenCalled()
   })
 
   describe('mapStateToProps', () => {

--- a/src/containers/StudentSurvey/__snapshots__/StudentSurvey.test.js.snap
+++ b/src/containers/StudentSurvey/__snapshots__/StudentSurvey.test.js.snap
@@ -18,6 +18,16 @@ exports[`StudentSurvey should match the snapshot 1`] = `
         "name": "name1",
       }
     }
+    questions={
+      Array [
+        Object {
+          "id": 7,
+        },
+        Object {
+          "id": 8,
+        },
+      ]
+    }
   />
   <Response
     collectResponses={[Function]}
@@ -27,6 +37,16 @@ exports[`StudentSurvey should match the snapshot 1`] = `
         "id": 2,
         "name": "name2",
       }
+    }
+    questions={
+      Array [
+        Object {
+          "id": 7,
+        },
+        Object {
+          "id": 8,
+        },
+      ]
     }
   />
   <button


### PR DESCRIPTION
### What does this change do?
- When a user is completing a survey for an individual group member, she must answer all questions before saving the survey
- Once a user has completed a survey for an individual group member, she cannot go back to review that member again (this prevents duplicates by disabling the button)
- A user must complete surveys for each group member before she can submit her survey response

### Link to related issues:
[Complete user story for students responding to surveys assigned to them](https://trello.com/c/q3fQrgvP/98-complete-user-story-for-students-responding-to-surveys-assigned-to-them)

### How was this change implemented?
- Added toast messages / disabled buttons when a user tries to submit incomplete feedback

### How is this change tested?
- Updated existing tests on Response component and added tests to StudentSurvey

### How does this PR make you feel?
![image](https://media.giphy.com/media/3Xw5TCn7VHfBCpPHxL/giphy-downsized.gif)
