### PR TITLE
Instructor surveys

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -37,3 +37,8 @@ export const setStudentSurveys = (surveys) => ({
   type: 'SET_STUDENT_SURVEYS',
   surveys
 })
+
+export const setInstructorSurveys = (surveys) => ({
+  type: 'SET_INSTRUCTOR_SURVEYS',
+  surveys
+})

--- a/src/actions/index.test.js
+++ b/src/actions/index.test.js
@@ -46,19 +46,51 @@ describe('actions', () => {
   })
 
   it('should have a type of SET_USER', () => {
-    const user = {
-      cohort: '1811',
-      id: 3,
-      name: 'Jessica Hansen',
-      program: 'F',
-      status: 'active'
-    }
+    const user = 'fL8Denah3foen'
     const expectedAction = {
       type: 'SET_USER',
       user
     }
 
     const result = actions.setUser(user)
+    expect(result).toEqual(expectedAction)
+  })
+
+  it('should have a type of SET_CURRENT_COHORT', () => {
+    const cohort = [
+      {id: 13, name:'1903', students: []}
+    ]
+    const expectedAction = {
+      type: 'SET_CURRENT_COHORT',
+      cohort
+    }
+
+    const result = actions.setCurrentCohort(cohort)
+    expect(result).toEqual(expectedAction)
+  })
+
+  it('should have a type of SET_ROLE', () => {
+    const role = "Instructor"
+    const expectedAction = {
+      type: 'SET_ROLE',
+      role
+    }
+
+    const result = actions.setRole(role)
+    expect(result).toEqual(expectedAction)
+  })
+
+  it('should have a type of SET_STUDENT_SURVEYS', () => {
+    const surveys = [
+      { id: 1, name: "Survey1"},
+      { id: 2, name: "Survey2"}
+    ]
+    const expectedAction = {
+      type: 'SET_STUDENT_SURVEYS',
+      surveys
+    }
+
+    const result = actions.setStudentSurveys(surveys)
     expect(result).toEqual(expectedAction)
   })
 

--- a/src/actions/index.test.js
+++ b/src/actions/index.test.js
@@ -61,4 +61,18 @@ describe('actions', () => {
     const result = actions.setUser(user)
     expect(result).toEqual(expectedAction)
   })
+
+  it('should have a type of SET_INSTRUCTOR_SURVEYS', () => {
+    const surveys = [
+      { id: 1, name: "Survey1"},
+      { id: 2, name: "Survey2"}
+    ]
+    const expectedAction = {
+      type: 'SET_INSTRUCTOR_SURVEYS',
+      surveys
+    }
+
+    const result = actions.setInstructorSurveys(surveys)
+    expect(result).toEqual(expectedAction)
+  })
 })

--- a/src/containers/InstructorDashboard/InstructorDashboard.js
+++ b/src/containers/InstructorDashboard/InstructorDashboard.js
@@ -3,22 +3,16 @@ import { connect } from 'react-redux'
 import { handleGet } from '../../thunks/handleGet'
 import { Link } from "react-router-dom";
 import SurveyCard from '../SurveyCard/SurveyCard'
+import { setInstructorSurveys } from '../../actions'
+import PropTypes from 'prop-types'
 
 export class InstructorDashboard extends Component {
-  constructor() {
-    super();
-    this.state = {
-      surveys: []
-    }
-  }
 
   async componentDidMount() {
     const myKey = await localStorage.getItem('currentUser')
     const url = `https://turing-feedback-api.herokuapp.com/api/v1/surveys?api_key=${myKey}`
     const surveys = await this.props.handleGet(url)
-    this.setState({
-      surveys: surveys
-    })
+    this.props.setInstructorSurveys(surveys)
   }
 
   render() {
@@ -28,7 +22,7 @@ export class InstructorDashboard extends Component {
           <button className='create-new-survey-button'>Create New Survey</button>
         </Link>
         <div className='inst-surveys'>
-          {this.state.surveys && this.state.surveys.map(survey => {
+          {this.props.instructorSurveys && this.props.instructorSurveys.map(survey => {
             return <SurveyCard key={survey.id}
                                surveyData={survey}/>
           })}
@@ -38,12 +32,21 @@ export class InstructorDashboard extends Component {
   }
 }
 
+InstructorDashboard.propTypes = {
+  user: PropTypes.string,
+  instructorSurveys: PropTypes.array,
+  handleGet: PropTypes.func,
+  setInstructorSurveys: PropTypes.func
+}
+
 export const mapStateToProps = (state) => ({
-  user: state.user
+  user: state.user,
+  instructorSurveys: state.instructorSurveys
 })
 
 export const mapDispatchToProps = (dispatch) => ({
-  handleGet: (url) => dispatch(handleGet(url))
+  handleGet: (url) => dispatch(handleGet(url)),
+  setInstructorSurveys: (surveys) => dispatch(setInstructorSurveys(surveys))
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(InstructorDashboard)

--- a/src/containers/InstructorDashboard/InstructorDashboard.test.js
+++ b/src/containers/InstructorDashboard/InstructorDashboard.test.js
@@ -1,22 +1,32 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { InstructorDashboard , mapStateToProps, mapDispatchToProps} from './InstructorDashboard'
+import { setInstructorSurveys } from '../../actions'
 jest.mock('../../thunks/handleGet')
 
 describe('InstructorDashboard', () => {
   let wrapper
   let handleGet
   let user
+  let mockSetInstructorSurveys
+  let mockInstructorSurveys
   let mockDispatch
 
   beforeEach(() => {
-    handleGet = jest.fn
+    mockInstructorSurveys = [
+      { id: 1, name: "Survey 1"},
+      { id: 2, name: "Survey 2"}
+    ]
+    handleGet = jest.fn()
+    mockSetInstructorSurveys = jest.fn()
     user = "2nf9rnad"
     mockDispatch = jest.fn()
     wrapper = shallow(
       <InstructorDashboard
         handleGet={handleGet}
         user={user}
+        instructorSurveys={mockInstructorSurveys}
+        setInstructorSurveys={mockSetInstructorSurveys}
       />
     )
   })
@@ -26,13 +36,21 @@ describe('InstructorDashboard', () => {
   })
 
   describe('mapStateToProps', () => {
-    it('should return a user as props', () => {
+    it('should return a user and instructor surveys as props', () => {
       const mockState = {
         user: "2nf9rnad",
+        instructorSurveys: [
+          { id: 1, name: "Survey1"},
+        { id: 2, name: "Survey2"}
+        ],
         fakeState: "fakeState"
       }
       const expected = {
-        user: "2nf9rnad"
+        user: "2nf9rnad",
+        instructorSurveys: [
+          { id: 1, name: "Survey1"},
+        { id: 2, name: "Survey2"}
+        ]
       }
       const mappedProps = mapStateToProps(mockState)
       expect(mappedProps).toEqual(expected)
@@ -41,12 +59,18 @@ describe('InstructorDashboard', () => {
 
   describe('mapDispatchToProps', () => {
     it('should return handleGet as props', () => {
-      const mockDispatch = jest.fn()
       const mockUrl = 'www.getSurveys.com'
       const handleGet = jest.fn()
       const actionToDispatch = handleGet(mockUrl)
       const mappedProps = mapDispatchToProps(mockDispatch)
       mappedProps.handleGet(mockUrl)
+      expect(mockDispatch).toHaveBeenCalledWith(actionToDispatch)
+    })
+
+    it('should return setInstructorSurveys as props', () => {
+      const actionToDispatch = setInstructorSurveys(mockInstructorSurveys)
+      const mappedProps = mapDispatchToProps(mockDispatch)
+      mappedProps.setInstructorSurveys(mockInstructorSurveys)
       expect(mockDispatch).toHaveBeenCalledWith(actionToDispatch)
     })
   })

--- a/src/containers/InstructorDashboard/__snapshots__/InstructorDashboard.test.js.snap
+++ b/src/containers/InstructorDashboard/__snapshots__/InstructorDashboard.test.js.snap
@@ -15,6 +15,25 @@ exports[`InstructorDashboard should match the snapshot 1`] = `
   </Link>
   <div
     className="inst-surveys"
-  />
+  >
+    <SurveyCard
+      key="1"
+      surveyData={
+        Object {
+          "id": 1,
+          "name": "Survey 1",
+        }
+      }
+    />
+    <SurveyCard
+      key="2"
+      surveyData={
+        Object {
+          "id": 2,
+          "name": "Survey 2",
+        }
+      }
+    />
+  </div>
 </div>
 `;

--- a/src/containers/RecipientForm/RecipientForm.js
+++ b/src/containers/RecipientForm/RecipientForm.js
@@ -2,7 +2,8 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { handlePost } from '../../thunks/handlePost'
-import { setCurrentCohort } from '../../actions'
+import { handleGet } from '../../thunks/handleGet'
+import { setCurrentCohort, setInstructorSurveys } from '../../actions'
 import cogoToast from 'cogo-toast';
 import shortid from 'shortid'
 import Team from '../../components/Team/Team'
@@ -15,7 +16,6 @@ export class RecipientForm extends Component {
       program: 'both',
       draggedStudent: {},
       group: [],
-      // displayTeams: "none",
       teams: [{id: shortid(), name: '', members: []}]
     }
   }
@@ -164,8 +164,12 @@ export class RecipientForm extends Component {
     this.handleSuccess()
   }
 
-  handleSuccess = () => {
+  handleSuccess = async () => {
     cogoToast.success('Your survey has been sent', {position: 'bottom-left'})
+    const myKey = await localStorage.getItem('currentUser')
+    const url = `https://turing-feedback-api.herokuapp.com/api/v1/surveys?api_key=${myKey}`
+    const surveys = await this.props.handleGet(url)
+    this.props.setInstructorSurveys(surveys)
     this.props.history.push('/dashboard')
   }
 
@@ -240,19 +244,28 @@ export class RecipientForm extends Component {
 
 RecipientForm.propTypes = {
   cohorts: PropTypes.array,
-  survey: PropTypes.object
+  survey: PropTypes.object,
+  currentCohort: PropTypes.array,
+  user: PropTypes.string,
+  instructorSurveys: PropTypes.array,
+  handlePost: PropTypes.func,
+  setCurrentCohort: PropTypes.func,
+  setCurrentCohort: PropTypes.func,
 }
 
 export const mapStateToProps = (state) => ({
   survey: state.survey,
   cohorts: state.cohorts,
   currentCohort: state.currentCohort,
-  user: state.user
+  user: state.user,
+  instructorSurveys: state.instructorSurveys
 })
 
 export const mapDispatchToProps = (dispatch) => ({
   handlePost: (url, options) => dispatch(handlePost(url, options)),
-  setCurrentCohort: (cohort) => dispatch(setCurrentCohort(cohort))
+  handleGet: (url) => dispatch(handleGet(url)),
+  setCurrentCohort: (cohort) => dispatch(setCurrentCohort(cohort)),
+  setInstructorSurveys: (surveys) => dispatch(setInstructorSurveys(surveys))
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(RecipientForm)

--- a/src/containers/StudentDashboard/StudentDashboard.js
+++ b/src/containers/StudentDashboard/StudentDashboard.js
@@ -6,12 +6,6 @@ import { setStudentSurveys } from '../../actions/'
 import PropTypes from 'prop-types'
 
 export class StudentDashboard extends Component {
-  constructor() {
-    super();
-    this.state = {
-     
-    }
-  }
 
   async componentDidMount() {
     const url = `https://turing-feedback-api.herokuapp.com/api/v1/surveys/pending?api_key=${localStorage.getItem('currentUser')}`

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -6,6 +6,7 @@ import { setCohortsReducer } from './setCohortsReducer'
 import { setUserReducer } from './setUserReducer'
 import { setRoleReducer } from './setRoleReducer'
 import { setStudentSurveysReducer } from './setStudentSurveysReducer'
+import { setInstructorSurveysReducer } from './setInstructorSurveysReducer'
 import { setCurrentCohortReducer } from './setCurrentCohortReducer'
 
 
@@ -17,7 +18,8 @@ const rootReducer = combineReducers({
   user: setUserReducer,
   currentCohort: setCurrentCohortReducer,
   role: setRoleReducer,
-  studentSurveys: setStudentSurveysReducer
+  studentSurveys: setStudentSurveysReducer,
+  instructorSurveys: setInstructorSurveysReducer
 })
 
 export default rootReducer;

--- a/src/reducers/setInstructorSurveysReducer.js
+++ b/src/reducers/setInstructorSurveysReducer.js
@@ -1,0 +1,8 @@
+export const setInstructorSurveysReducer = (state = [], action) => {
+  switch(action.type) {
+    case 'SET_INSTRUCTOR_SURVEYS':
+      return action.surveys
+    default: 
+      return state
+  }
+}

--- a/src/reducers/setInstructorSurveysReducer.test.js
+++ b/src/reducers/setInstructorSurveysReducer.test.js
@@ -1,0 +1,22 @@
+import { setInstructorSurveysReducer } from './setInstructorSurveysReducer'
+import * as actions from '../actions'
+
+describe('setInstructorSurveysReducer', () => {
+  const initialState = []
+
+  it('should return state by default', () => {
+    const expected = []
+    const result = setInstructorSurveysReducer(initialState, {})
+    expect(result).toEqual(expected)
+  })
+
+  it('should return surveys to state if the type is SET_INSTRUCTOR_SURVEYS', () => {
+    const surveys = [
+      { id: 1, name: "Survey 1"},
+      { id: 2, name: "Survey 2"}
+    ]
+    const action = actions.setInstructorSurveys(surveys)
+    const result = setInstructorSurveysReducer(initialState, action)
+    expect(result).toEqual(surveys)
+  })
+})

--- a/src/reducers/setUserReducer.js
+++ b/src/reducers/setUserReducer.js
@@ -1,4 +1,4 @@
-export const setUserReducer = (state = {}, action) => {
+export const setUserReducer = (state = '', action) => {
   switch(action.type) {
     case 'SET_USER':
       return action.user 

--- a/src/reducers/setUserReducer.test.js
+++ b/src/reducers/setUserReducer.test.js
@@ -3,20 +3,14 @@ import * as actions from '../actions'
 
 describe('setUserReducer', () => {
   it('should return state by default', () => {
-    const expected = {}
-    const result = setUserReducer(undefined, {})
+    const expected = ''
+    const result = setUserReducer(undefined, '')
     expect(result).toEqual(expected)
   })
 
   it('should set state with a user object if the type is SET_USER', () => {
-    const initialState = {}
-    const user = {
-      cohort: '1811',
-      id: 3,
-      name: 'Jessica Hansen',
-      program: 'F',
-      status: 'active'
-    }
+    const initialState = ''
+    const user = 'fL8Denah3foen'
     const action = actions.setUser(user)
     const result = setUserReducer(initialState, action)
     expect(result).toEqual(user)


### PR DESCRIPTION
### What does this change do?
- sets instructor surveys in state
- refreshes those surveys after another is created so that when routed back to dashboard the change will be reflected

### Link to related issues:
[Find another way to re-render InstructorDashboard after a surveys POST.](https://trello.com/c/h9YzvEg0/117-find-another-way-to-re-render-instructordashboard-after-a-surveys-post)

### How was this change implemented?
- removed surveys from local state
- removes useless constructors from Instructor/Student dashboard
- fetch most recent surveys after successfully creating once

### How is this change tested?
- action and reducer are tested
- index.test.js tests were all updated 
- mDTP and mSTP tests updated in Instructor Dashboard

### Link to next issue:
[Update styling for PageNotFound Component](https://trello.com/c/MGF8aYmN/84-update-styling-for-pagenotfound-component)

### How does this PR make you feel?
![image](https://media.giphy.com/media/euPUcgtx08ul1mmoj8/giphy-downsized.gif)
