### PR TITLE
validates login response before redirect

### DIFF
--- a/src/containers/Login/Login.js
+++ b/src/containers/Login/Login.js
@@ -43,11 +43,7 @@ export class Login extends Component {
     }
     this.props.handlePost(url, options)
     const data = await this.props.handlePost(url, options)
-    if(this.props.error.length) {
-      this.warnToast('Incorrect login. Please try again')
-    } else {
-      this.handleUser(data)
-    }
+    data ? this.handleUser(data) : this.warnToast('Incorrect login. Please try again')
   }
 
   registerUser = async (user) => {
@@ -65,7 +61,7 @@ export class Login extends Component {
       }
     }
     const data = await this.props.handlePost(url, options)
-      this.handleUser(data)
+    this.handleUser(data)
   }
 
   warnToast = (message) => {


### PR DESCRIPTION
### What does this change do?
- Implements a fix for the app crashing when a user attempts login with invalid creds

### Link to related issues:

### How was this change implemented?
- If the login response is undefined, it presents a toast warning and does not redirect

### How is this change tested?

### Link to next issue:

### How does this PR make you feel?
![image](LINK_HERE)
