### PR TITLE
Student reselection fix

### DIFF
--- a/src/containers/RecipientForm/RecipientForm.js
+++ b/src/containers/RecipientForm/RecipientForm.js
@@ -32,13 +32,24 @@ export class RecipientForm extends Component {
     })
   }
 
+  rejectSelectedStudents = (cohort) => {
+    let selectedStudents = []
+    for(let i = 0; i < this.state.teams.length; i++) {
+      for(let k = 0; k < this.state.teams[i].members.length; k++) {
+        selectedStudents.push(this.state.teams[i].members[k].id)
+      }
+    }
+    return cohort.filter((student => !selectedStudents.includes(student.id)))
+  }
+
   handleAssignGroups = async () => {
     const { cohort_id, program } = this.state
     let url
     this.state.program === "both"
     ? url = `https://turing-feedback-api.herokuapp.com/api/v1/students?cohort=${cohort_id}`
     : url = `https://turing-feedback-api.herokuapp.com/api/v1/students?cohort=${cohort_id}&&program=${program}`
-    const cohort = await this.props.handleGet(url)
+    let cohort = await this.props.handleGet(url)
+    cohort = this.rejectSelectedStudents(cohort)
     await this.props.setCurrentCohort(cohort)
   }
 

--- a/src/containers/RecipientForm/RecipientForm.js
+++ b/src/containers/RecipientForm/RecipientForm.js
@@ -33,13 +33,17 @@ export class RecipientForm extends Component {
   }
 
   rejectSelectedStudents = (cohort) => {
-    let selectedStudents = []
-    for(let i = 0; i < this.state.teams.length; i++) {
-      for(let k = 0; k < this.state.teams[i].members.length; k++) {
-        selectedStudents.push(this.state.teams[i].members[k].id)
+    if (cohort) {
+      let selectedStudents = []
+      for(let i = 0; i < this.state.teams.length; i++) {
+        for(let k = 0; k < this.state.teams[i].members.length; k++) {
+          selectedStudents.push(this.state.teams[i].members[k].id)
+        }
       }
+      return cohort.filter((student => !selectedStudents.includes(student.id)))
+    } else {
+      return cohort
     }
-    return cohort.filter((student => !selectedStudents.includes(student.id)))
   }
 
   handleAssignGroups = async () => {


### PR DESCRIPTION
### What does this change do?

Adds logic to filter already selected students from current cohort following fetch to prevent ability to place the same student multiple times.

### Link to related issues:

N/A

### How was this change implemented?

Added a function to remove already selected students from the displayed group members that can be dropped.

### How is this change tested?

No additional testing added.

### Link to next issue:

### How does this PR make you feel?
![image](LINK_HERE)
