### PR TITLE
Refresh inst surveys

### DIFF
--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -51,6 +51,7 @@ export class Question extends Component {
             placeholder="Add Your Question Text"
             value={this.state.questionTitle}
             onChange={this.handleTitleChange}
+            autoComplete="off"
           />
         </div>
         <div className='option-container'>
@@ -65,7 +66,9 @@ export class Question extends Component {
               id='op1'
               className='option'
               value={this.state.option_1.description}
-              onChange={this.handleChange} />
+              onChange={this.handleChange} 
+              autoComplete="off"
+            />
           </div>
           <div className='option'>
             <input
@@ -77,7 +80,9 @@ export class Question extends Component {
               name="option_2"
               className='option'
               value={this.state.option_2.description}
-              onChange={this.handleChange} />
+              onChange={this.handleChange} 
+              autoComplete="off"
+            />
           </div>
           <div className='option'>
             <input
@@ -89,7 +94,9 @@ export class Question extends Component {
               name="option_3"
               className='option'
               value={this.state.option_3.description}
-              onChange={this.handleChange} />
+              onChange={this.handleChange} 
+              autoComplete="off"  
+            />
           </div>
           <div className='option'>
             <input
@@ -101,7 +108,9 @@ export class Question extends Component {
               name="option_4"
               className='option'
               value={this.state.option_4.description}
-              onChange={this.handleChange} />
+              onChange={this.handleChange} 
+              autoComplete="off"  
+            />
           </div>
         </div>
       </form>

--- a/src/components/Question/Question.scss
+++ b/src/components/Question/Question.scss
@@ -16,6 +16,9 @@
   border-bottom: solid $main-grey 1px;
   font-size: 20px;
   color: $accent-charcoal;
+  &:focus {
+    outline: none;
+  }
 }
 
 .option-container {

--- a/src/components/Question/__snapshots__/Question.test.js.snap
+++ b/src/components/Question/__snapshots__/Question.test.js.snap
@@ -7,6 +7,7 @@ exports[`Question should match the snapshot 1`] = `
 >
   <div>
     <input
+      autoComplete="off"
       className="question-input"
       name="questionTitle"
       onChange={[Function]}
@@ -26,6 +27,7 @@ exports[`Question should match the snapshot 1`] = `
         type="radio"
       />
       <input
+        autoComplete="off"
         className="option"
         id="op1"
         name="option_1"
@@ -43,6 +45,7 @@ exports[`Question should match the snapshot 1`] = `
         type="radio"
       />
       <input
+        autoComplete="off"
         className="option"
         name="option_2"
         onChange={[Function]}
@@ -59,6 +62,7 @@ exports[`Question should match the snapshot 1`] = `
         type="radio"
       />
       <input
+        autoComplete="off"
         className="option"
         name="option_3"
         onChange={[Function]}
@@ -75,6 +79,7 @@ exports[`Question should match the snapshot 1`] = `
         type="radio"
       />
       <input
+        autoComplete="off"
         className="option"
         name="option_4"
         onChange={[Function]}

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -54,6 +54,7 @@ export class App extends Component {
           <Switch>
             <Route exact path='/' component={loginRoute()}
             />
+            <Route path='/register' component={Login} />
             <Route exact path='/dashboard' component={validateInstructor() ? InstructorDashboard : PageNotFound}
             />
             <Route exact path='/new-survey' component={validateInstructor() ? NewSurvey : PageNotFound}

--- a/src/containers/App/__snapshots__/App.test.js.snap
+++ b/src/containers/App/__snapshots__/App.test.js.snap
@@ -18,6 +18,10 @@ exports[`App should match the snapshot 1`] = `
       />
       <Route
         component={[Function]}
+        path="/register"
+      />
+      <Route
+        component={[Function]}
         exact={true}
         path="/dashboard"
       />

--- a/src/containers/Login/Login.js
+++ b/src/containers/Login/Login.js
@@ -4,7 +4,7 @@ import { setUser, setRole } from '../../actions'
 import RegisterForm from '../RegisterForm/RegisterForm'
 import LoginForm from '../LoginForm/LoginForm'
 import { handlePost } from '../../thunks/handlePost'
-import { withRouter } from 'react-router-dom'
+import { Route, Switch, withRouter } from 'react-router-dom'
 import cogoToast from 'cogo-toast';
 
 export class Login extends Component {
@@ -16,6 +16,7 @@ export class Login extends Component {
   }
 
   createAccount = () => {
+    this.props.history.push('/register')
     this.setState({
       newUser: true
     })
@@ -89,15 +90,19 @@ export class Login extends Component {
   render() {
     return(
       <div className='login-landing'>
-        {!this.state.newUser &&
-          <LoginForm
-            createAccount={this.createAccount}
-            handleLogin={this.handleLogin}
-          />}
-        {this.state.newUser &&
-          <RegisterForm
-            handleLogin={this.handleLogin}
-          />}
+        <Switch>
+          <Route exact path='/'
+            render={() => <LoginForm  
+              createAccount={this.createAccount} 
+              handleLogin={this.handleLogin}
+              />}
+          />
+          <Route exact path='/register'
+            render={() => <RegisterForm 
+              handleLogin={this.handleLogin}
+            />}
+          />
+        </Switch>
       </div>
     )
   }

--- a/src/containers/Login/Login.test.js
+++ b/src/containers/Login/Login.test.js
@@ -45,6 +45,11 @@ describe('Login', () => {
     expect(wrapper.state('newUser')).toBe(true)
   })
 
+  it('should push to /register when createAccount is called', () => {
+    wrapper.instance().createAccount()
+    expect(wrapper.instance().props.history.push).toHaveBeenCalled()
+  })
+
   it('should call loginUser when handleLogin is called', () => {
     const loginUserSpy = jest.spyOn(wrapper.instance(), 'loginUser')
     wrapper.setState({newUser: false})

--- a/src/containers/Login/__snapshots__/Login.test.js.snap
+++ b/src/containers/Login/__snapshots__/Login.test.js.snap
@@ -4,9 +4,17 @@ exports[`Login should match the snapshot 1`] = `
 <div
   className="login-landing"
 >
-  <LoginForm
-    createAccount={[Function]}
-    handleLogin={[Function]}
-  />
+  <Switch>
+    <Route
+      exact={true}
+      path="/"
+      render={[Function]}
+    />
+    <Route
+      exact={true}
+      path="/register"
+      render={[Function]}
+    />
+  </Switch>
 </div>
 `;

--- a/src/containers/NewSurvey/NewSurvey.js
+++ b/src/containers/NewSurvey/NewSurvey.js
@@ -90,6 +90,7 @@ export class NewSurvey extends Component {
             placeholder="Add Survey Name"
             value={this.state.surveyName}
             onChange={this.handleChange}
+            autoComplete="off"
           />
           <label className="begin-create-survey-label">
             <p className="exp">Expiration Date:</p>

--- a/src/containers/RecipientForm/RecipientForm.js
+++ b/src/containers/RecipientForm/RecipientForm.js
@@ -150,7 +150,7 @@ export class RecipientForm extends Component {
     this.postSurvey(formattedGroups)
   }
 
-  postSurvey = (formattedGroups) => {
+  postSurvey = async (formattedGroups) => {
     const { survey } = this.props
     const url = "https://turing-feedback-api.herokuapp.com/api/v1/surveys"
     const options = {
@@ -169,7 +169,7 @@ export class RecipientForm extends Component {
           'Content-Type': 'application/json'
         }
     }
-    this.props.handlePost(url, options)
+    await this.props.handlePost(url, options)
     this.handleSuccess()
   }
 
@@ -179,7 +179,7 @@ export class RecipientForm extends Component {
     const myKey = await localStorage.getItem('currentUser')
     const url = `https://turing-feedback-api.herokuapp.com/api/v1/surveys?api_key=${myKey}`
     const surveys = await this.props.handleGet(url)
-    this.props.setInstructorSurveys(surveys)
+    await this.props.setInstructorSurveys(surveys)
     this.props.history.push('/dashboard')
   }
 

--- a/src/containers/RegisterForm/RegisterForm.js
+++ b/src/containers/RegisterForm/RegisterForm.js
@@ -105,7 +105,7 @@ export class RegisterForm extends Component {
           </div>
         </div>
         <button className='login-button' onClick={this.checkPassword}>
-          Login
+          Register
         </button> 
       </form>
     )

--- a/src/containers/RegisterForm/__snapshots__/RegisterForm.test.js.snap
+++ b/src/containers/RegisterForm/__snapshots__/RegisterForm.test.js.snap
@@ -99,7 +99,7 @@ exports[`RegisterForm should match the snapshot 1`] = `
     className="login-button"
     onClick={[Function]}
   >
-    Login
+    Register
   </button>
 </form>
 `;


### PR DESCRIPTION
### What does this change do?
- Fixes dashboard bug for newly registered instructors

### Link to related issues:
- [Fix bug for instructor registering the first time, creating a survey and the survey not refreshing when they route back to dashboard](https://trello.com/c/kuWgdybf/126-fix-bug-for-instructor-registering-the-first-time-creating-a-survey-and-the-survey-not-refreshing-when-they-route-back-to-dashbo)

### How was this change implemented?
- await handlePost and setInstructorSurveys before pushing to '/dashboard'

### How is this change tested?
- no new tests necessary

### Link to next issue:

### How does this PR make you feel?
![image](https://media.giphy.com/media/c7vW1CgVpmCJLHp919/giphy-downsized.gif)
