### PR TITLE
Response order

### DIFF
--- a/src/components/Question/Question.js
+++ b/src/components/Question/Question.js
@@ -6,10 +6,10 @@ export class Question extends Component {
     this.state = {
       id: this.props.id,
       questionTitle: '',
-      option_1: {pointValue: 1, description: ''},
-      option_2: {pointValue: 2, description: ''},
-      option_3: {pointValue: 3, description: ''},
-      option_4: {pointValue: 4, description: ''}
+      option_1: {pointValue: 4, description: ''},
+      option_2: {pointValue: 3, description: ''},
+      option_3: {pointValue: 2, description: ''},
+      option_4: {pointValue: 1, description: ''}
     }
   }
 
@@ -59,9 +59,10 @@ export class Question extends Component {
             <input
               type="radio"
               name="radio" />
+            <p>4.</p>
             <input
               type="text"
-              placeholder="Add Response Description 1"
+              placeholder="Add Response Description"
               name="option_1"
               id='op1'
               className='option'
@@ -74,9 +75,10 @@ export class Question extends Component {
             <input
               type="radio"
               name="radio" />
+            <p>3.</p>
             <input
               type="text"
-              placeholder="Add Response Description 2"
+              placeholder="Add Response Description"
               name="option_2"
               className='option'
               value={this.state.option_2.description}
@@ -88,9 +90,10 @@ export class Question extends Component {
             <input
               type="radio"
               name="radio" />
+            <p>2.</p>
             <input
               type="text"
-              placeholder="Add Response Description 3"
+              placeholder="Add Response Description"
               name="option_3"
               className='option'
               value={this.state.option_3.description}
@@ -102,9 +105,10 @@ export class Question extends Component {
             <input
               type="radio"
               name="radio" />
+            <p>1.</p>
             <input
               type="text"
-              placeholder="Add Response Description 4"
+              placeholder="Add Response Description"
               name="option_4"
               className='option'
               value={this.state.option_4.description}

--- a/src/components/Question/Question.scss
+++ b/src/components/Question/Question.scss
@@ -30,8 +30,11 @@
   width: 95%;
   font-size: 13px;
   height: 50px;
+  padding: 0px;
   padding-left: 5px;
   border: none;
+  display: flex;
+  align-items: center;
   color: $accent-charcoal;
     &:focus {
       outline: none;

--- a/src/components/Question/Question.test.js
+++ b/src/components/Question/Question.test.js
@@ -21,10 +21,10 @@ describe('Question', () => {
     const defaultState = {
       id: 'abc',
       questionTitle: '',
-      option_1: {pointValue: 1, description: ''},
-      option_2: {pointValue: 2, description: ''},
-      option_3: {pointValue: 3, description: ''},
-      option_4: {pointValue: 4, description: ''}
+      option_1: {pointValue: 4, description: ''},
+      option_2: {pointValue: 3, description: ''},
+      option_3: {pointValue: 2, description: ''},
+      option_4: {pointValue: 1, description: ''}
     }
 
     expect(wrapper.state()).toEqual(defaultState)
@@ -33,7 +33,7 @@ describe('Question', () => {
   it('should update description in state on change', () => {
     const mockEvent = { target: { name: 'option_1', value: 'First Option'}}
     wrapper.find('#op1').simulate('change', mockEvent)
-    expect(wrapper.state('option_1')).toEqual({ "pointValue": 1, "description": 'First Option'})
+    expect(wrapper.state('option_1')).toEqual({ "pointValue": 4, "description": 'First Option'})
   })
 
   it('should update questionTitle in state on change', () => {
@@ -47,17 +47,17 @@ describe('Question', () => {
     const mockState = {
       id: 'abd',
       questionTitle: 'New Question',
-      option_1: {pointValue: 1, description: 'a'},
-      option_2: {pointValue: 2, description: 'b'},
-      option_3: {pointValue: 3, description: 'c'},
-      option_4: {pointValue: 4, description: 'd'}
+      option_1: {pointValue: 4, description: 'a'},
+      option_2: {pointValue: 3, description: 'b'},
+      option_3: {pointValue: 2, description: 'c'},
+      option_4: {pointValue: 1, description: 'd'}
     }
 
     const optionsArr = [
-      { option_1: {pointValue: 1, description: 'a'} },
-      { option_2: {pointValue: 2, description: 'b'} },
-      { option_3: {pointValue: 3, description: 'c'} },
-      { option_4: {pointValue: 4, description: 'd'} }
+      { option_1: {pointValue: 4, description: 'a'} },
+      { option_2: {pointValue: 3, description: 'b'} },
+      { option_3: {pointValue: 2, description: 'c'} },
+      { option_4: {pointValue: 1, description: 'd'} }
     ]
 
     wrapper.setState(mockState)

--- a/src/components/Question/__snapshots__/Question.test.js.snap
+++ b/src/components/Question/__snapshots__/Question.test.js.snap
@@ -26,13 +26,16 @@ exports[`Question should match the snapshot 1`] = `
         name="radio"
         type="radio"
       />
+      <p>
+        4.
+      </p>
       <input
         autoComplete="off"
         className="option"
         id="op1"
         name="option_1"
         onChange={[Function]}
-        placeholder="Add Response Description 1"
+        placeholder="Add Response Description"
         type="text"
         value=""
       />
@@ -44,12 +47,15 @@ exports[`Question should match the snapshot 1`] = `
         name="radio"
         type="radio"
       />
+      <p>
+        3.
+      </p>
       <input
         autoComplete="off"
         className="option"
         name="option_2"
         onChange={[Function]}
-        placeholder="Add Response Description 2"
+        placeholder="Add Response Description"
         type="text"
         value=""
       />
@@ -61,12 +67,15 @@ exports[`Question should match the snapshot 1`] = `
         name="radio"
         type="radio"
       />
+      <p>
+        2.
+      </p>
       <input
         autoComplete="off"
         className="option"
         name="option_3"
         onChange={[Function]}
-        placeholder="Add Response Description 3"
+        placeholder="Add Response Description"
         type="text"
         value=""
       />
@@ -78,12 +87,15 @@ exports[`Question should match the snapshot 1`] = `
         name="radio"
         type="radio"
       />
+      <p>
+        1.
+      </p>
       <input
         autoComplete="off"
         className="option"
         name="option_4"
         onChange={[Function]}
-        placeholder="Add Response Description 4"
+        placeholder="Add Response Description"
         type="text"
         value=""
       />

--- a/src/containers/ResponseCard/ResponseCard.js
+++ b/src/containers/ResponseCard/ResponseCard.js
@@ -28,19 +28,10 @@ export class ResponseCard extends Component {
               type="radio" 
               name="option"
               id="op1" 
-              value={this.props.question.options[3].id}
+              value={this.props.question.options[0].id}
               onChange={this.handleChange}
             />
-            <p className='response-description'>1. {this.props.question.options[3].description}</p>
-          </div>
-          <div className='response-option'>
-            <input 
-              type="radio" 
-              name="option"
-              value={this.props.question.options[2].id}
-              onChange={this.handleChange}
-            />
-            <p className='response-description'>2. {this.props.question.options[2].description}</p>
+            <p className='response-description'>4. {this.props.question.options[0].description}</p>
           </div>
           <div className='response-option'>
             <input 
@@ -55,10 +46,19 @@ export class ResponseCard extends Component {
             <input 
               type="radio" 
               name="option"
-              value={this.props.question.options[0].id}
+              value={this.props.question.options[2].id}
               onChange={this.handleChange}
             />
-            <p className='response-description'>4. {this.props.question.options[0].description}</p>
+            <p className='response-description'>2. {this.props.question.options[2].description}</p>
+          </div>
+          <div className='response-option'>
+            <input 
+              type="radio" 
+              name="option"
+              value={this.props.question.options[3].id}
+              onChange={this.handleChange}
+            />
+            <p className='response-description'>1. {this.props.question.options[3].description}</p>
           </div>
         </div>
       </form>

--- a/src/containers/ResponseCard/ResponseCard.js
+++ b/src/containers/ResponseCard/ResponseCard.js
@@ -31,7 +31,7 @@ export class ResponseCard extends Component {
               value={this.props.question.options[3].id}
               onChange={this.handleChange}
             />
-            <p className='response-description'>{this.props.question.options[3].description}</p>
+            <p className='response-description'>1. {this.props.question.options[3].description}</p>
           </div>
           <div className='response-option'>
             <input 
@@ -40,7 +40,7 @@ export class ResponseCard extends Component {
               value={this.props.question.options[2].id}
               onChange={this.handleChange}
             />
-            <p className='response-description'>{this.props.question.options[2].description}</p>
+            <p className='response-description'>2. {this.props.question.options[2].description}</p>
           </div>
           <div className='response-option'>
             <input 
@@ -49,7 +49,7 @@ export class ResponseCard extends Component {
               value={this.props.question.options[1].id}
               onChange={this.handleChange}
             />
-            <p className='response-description'>{this.props.question.options[1].description}</p>
+            <p className='response-description'>3. {this.props.question.options[1].description}</p>
           </div>
           <div className='response-option'>
             <input 
@@ -58,7 +58,7 @@ export class ResponseCard extends Component {
               value={this.props.question.options[0].id}
               onChange={this.handleChange}
             />
-            <p className='response-description'>{this.props.question.options[0].description}</p>
+            <p className='response-description'>4. {this.props.question.options[0].description}</p>
           </div>
         </div>
       </form>

--- a/src/containers/ResponseCard/ResponseCard.js
+++ b/src/containers/ResponseCard/ResponseCard.js
@@ -28,19 +28,10 @@ export class ResponseCard extends Component {
               type="radio" 
               name="option"
               id="op1" 
-              value={this.props.question.options[0].id}
+              value={this.props.question.options[3].id}
               onChange={this.handleChange}
             />
-            <p className='response-description'>{this.props.question.options[0].description}</p>
-          </div>
-          <div className='response-option'>
-            <input 
-              type="radio" 
-              name="option"
-              value={this.props.question.options[1].id}
-              onChange={this.handleChange}
-            />
-            <p className='response-description'>{this.props.question.options[1].description}</p>
+            <p className='response-description'>{this.props.question.options[3].description}</p>
           </div>
           <div className='response-option'>
             <input 
@@ -55,10 +46,19 @@ export class ResponseCard extends Component {
             <input 
               type="radio" 
               name="option"
-              value={this.props.question.options[3].id}
+              value={this.props.question.options[1].id}
               onChange={this.handleChange}
             />
-            <p className='response-description'>{this.props.question.options[3].description}</p>
+            <p className='response-description'>{this.props.question.options[1].description}</p>
+          </div>
+          <div className='response-option'>
+            <input 
+              type="radio" 
+              name="option"
+              value={this.props.question.options[0].id}
+              onChange={this.handleChange}
+            />
+            <p className='response-description'>{this.props.question.options[0].description}</p>
           </div>
         </div>
       </form>

--- a/src/containers/ResponseCard/__snapshots__/ResponseCard.test.js.snap
+++ b/src/containers/ResponseCard/__snapshots__/ResponseCard.test.js.snap
@@ -20,29 +20,13 @@ exports[`ResponseCard should match the snapshot 1`] = `
         name="option"
         onChange={[Function]}
         type="radio"
-        value={4}
+        value={1}
       />
       <p
         className="response-description"
       >
-        1. 
-        Option Four
-      </p>
-    </div>
-    <div
-      className="response-option"
-    >
-      <input
-        name="option"
-        onChange={[Function]}
-        type="radio"
-        value={3}
-      />
-      <p
-        className="response-description"
-      >
-        2. 
-        Option Three
+        4. 
+        Option One
       </p>
     </div>
     <div
@@ -68,13 +52,29 @@ exports[`ResponseCard should match the snapshot 1`] = `
         name="option"
         onChange={[Function]}
         type="radio"
-        value={1}
+        value={3}
       />
       <p
         className="response-description"
       >
-        4. 
-        Option One
+        2. 
+        Option Three
+      </p>
+    </div>
+    <div
+      className="response-option"
+    >
+      <input
+        name="option"
+        onChange={[Function]}
+        type="radio"
+        value={4}
+      />
+      <p
+        className="response-description"
+      >
+        1. 
+        Option Four
       </p>
     </div>
   </div>

--- a/src/containers/ResponseCard/__snapshots__/ResponseCard.test.js.snap
+++ b/src/containers/ResponseCard/__snapshots__/ResponseCard.test.js.snap
@@ -20,27 +20,12 @@ exports[`ResponseCard should match the snapshot 1`] = `
         name="option"
         onChange={[Function]}
         type="radio"
-        value={1}
+        value={4}
       />
       <p
         className="response-description"
       >
-        Option One
-      </p>
-    </div>
-    <div
-      className="response-option"
-    >
-      <input
-        name="option"
-        onChange={[Function]}
-        type="radio"
-        value={2}
-      />
-      <p
-        className="response-description"
-      >
-        Option Two
+        Option Four
       </p>
     </div>
     <div
@@ -65,12 +50,27 @@ exports[`ResponseCard should match the snapshot 1`] = `
         name="option"
         onChange={[Function]}
         type="radio"
-        value={4}
+        value={2}
       />
       <p
         className="response-description"
       >
-        Option Four
+        Option Two
+      </p>
+    </div>
+    <div
+      className="response-option"
+    >
+      <input
+        name="option"
+        onChange={[Function]}
+        type="radio"
+        value={1}
+      />
+      <p
+        className="response-description"
+      >
+        Option One
       </p>
     </div>
   </div>

--- a/src/containers/ResponseCard/__snapshots__/ResponseCard.test.js.snap
+++ b/src/containers/ResponseCard/__snapshots__/ResponseCard.test.js.snap
@@ -25,6 +25,7 @@ exports[`ResponseCard should match the snapshot 1`] = `
       <p
         className="response-description"
       >
+        1. 
         Option Four
       </p>
     </div>
@@ -40,6 +41,7 @@ exports[`ResponseCard should match the snapshot 1`] = `
       <p
         className="response-description"
       >
+        2. 
         Option Three
       </p>
     </div>
@@ -55,6 +57,7 @@ exports[`ResponseCard should match the snapshot 1`] = `
       <p
         className="response-description"
       >
+        3. 
         Option Two
       </p>
     </div>
@@ -70,6 +73,7 @@ exports[`ResponseCard should match the snapshot 1`] = `
       <p
         className="response-description"
       >
+        4. 
         Option One
       </p>
     </div>


### PR DESCRIPTION
### What does this change do?
- Reverse order for options displayed on student surveys
- Add point values to option descriptions so that results make a little more sense

### Link to related issues:
- [Questions are displayed in reverse order when the student goes to complete the survey](https://trello.com/c/s4ZP5uDJ/124-questions-are-displayed-in-reverse-order-when-the-student-goes-to-complete-the-survey)

### How was this change implemented?
- Very minor tweaks to ResponseCard.js component

### How is this change tested?
- Updated snapshot

### Link to next issue:

### How does this PR make you feel?
![image](https://media.giphy.com/media/l0NgS8Fe2ZChPJapy/giphy.gif)
